### PR TITLE
[Magento2] Ajustar o parse dos juros comprador no SDK

### DIFF
--- a/src/Parser/RakutenPay/Checkout.php
+++ b/src/Parser/RakutenPay/Checkout.php
@@ -46,11 +46,10 @@ class Checkout implements Parser
     {
         $response = self::getTransactionCheckout();
         $data = json_decode($webservice->getResponse()->getResult(), true);
-        $payments = array_shift($data['payments']);
+        $installments = array_column($data['payments'], 'installments');
 
         $response->setResult($data['result'])
-            ->setMethod($payments['method'])
-            ->setInstallments($payments['installments'])
+            ->setInstallments(array_shift($installments))
             ->setMessage('')
             ->setResponse($webservice->getResponse());
 

--- a/src/Parser/RakutenPay/Transaction/Checkout.php
+++ b/src/Parser/RakutenPay/Transaction/Checkout.php
@@ -44,11 +44,6 @@ class Checkout extends Transaction
     private $installments = [];
 
     /**
-     * @var string
-     */
-    private $method;
-
-    /**
      * @var Response
      */
     private $response;
@@ -105,25 +100,6 @@ class Checkout extends Transaction
     public function setInstallments(array $installments)
     {
         $this->installments = $installments;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMethod()
-    {
-        return $this->method;
-    }
-
-    /**
-     * @param string $method
-     * @return $this
-     */
-    public function setMethod($method)
-    {
-        $this->method = $method;
 
         return $this;
     }

--- a/tests/Unit/Parser/RakutenPay/CheckoutTest.php
+++ b/tests/Unit/Parser/RakutenPay/CheckoutTest.php
@@ -49,7 +49,6 @@ class CheckoutTest extends TestCase
         $this->assertFalse($response->isError());
         $this->assertInstanceOf(Response::class, $response->getResponse());
         $this->assertCount(12, $response->getInstallments());
-        $this->assertEquals("credit_card", $response->getMethod());
         $this->assertEquals("success", $response->getResult());
         $this->assertEmpty($response->getMessage());
     }
@@ -85,114 +84,118 @@ class CheckoutTest extends TestCase
     {
         $jsonSuccess = '
         {
-           "result":"success",
-           "payments":[
-              {
-                 "method":"credit_card",
-                 "installments":[
-                    {
-                       "total":5149.5,
-                       "quantity":1,
-                       "interest_percent":2.99,
-                       "interest_amount":149.5,
-                       "installment_amount":5149.5
-                    },
-                    {
-                       "total":5226.5,
-                       "quantity":2,
-                       "interest_percent":4.53,
-                       "interest_amount":226.5,
-                       "installment_amount":2613.25
-                    },
-                    {
-                       "total":5304.51,
-                       "quantity":3,
-                       "interest_percent":6.09,
-                       "interest_amount":304.51,
-                       "installment_amount":1768.17
-                    },
-                    {
-                       "total":5385.0,
-                       "quantity":4,
-                       "interest_percent":7.7,
-                       "interest_amount":385.0,
-                       "installment_amount":1346.25
-                    },
-                    {
-                       "total":5466.5,
-                       "quantity":5,
-                       "interest_percent":9.33,
-                       "interest_amount":466.5,
-                       "installment_amount":1093.3
-                    },
-                    {
-                       "total":5548.02,
-                       "quantity":6,
-                       "interest_percent":10.96,
-                       "interest_amount":548.02,
-                       "installment_amount":924.67
-                    },
-                    {
-                       "total":5631.5,
-                       "quantity":7,
-                       "interest_percent":12.63,
-                       "interest_amount":631.5,
-                       "installment_amount":804.5
-                    },
-                    {
-                       "total":5722.0,
-                       "quantity":8,
-                       "interest_percent":14.44,
-                       "interest_amount":722.0,
-                       "installment_amount":715.25
-                    },
-                    {
-                       "total":5809.5,
-                       "quantity":9,
-                       "interest_percent":16.19,
-                       "interest_amount":809.5,
-                       "installment_amount":645.5
-                    },
-                    {
-                       "total":5900.5,
-                       "quantity":10,
-                       "interest_percent":18.01,
-                       "interest_amount":900.5,
-                       "installment_amount":590.05
-                    },
-                    {
-                       "total":5983.01,
-                       "quantity":11,
-                       "interest_percent":19.66,
-                       "interest_amount":983.01,
-                       "installment_amount":543.91
-                    },
-                    {
-                       "total":6082.56,
-                       "quantity":12,
-                       "interest_percent":21.65,
-                       "interest_amount":1082.56,
-                       "installment_amount":506.88
-                    }
-                 ],
-                 "cards":[
-        
-                 ],
-                 "brands":[
-                    "visa",
-                    "mastercard",
-                    "diners",
-                    "hipercard",
-                    "amex",
-                    "elo"
-                 ],
-                 "amount":5.0e3
-              },
-              {
-                 "method":"billet",
-                 "amount":5.0e3
-              }
-           ]
+          "result": "success",
+          "payments": [
+            {
+              "method": "balance",
+              "currency": "BRL",
+              "amount": 30686.28
+            },
+            {
+              "method": "credit_card",
+              "installments": [
+                {
+                  "total": 109.17,
+                  "quantity": 1,
+                  "interest_percent": 2.99,
+                  "interest_amount": 3.17,
+                  "installment_amount": 109.17
+                },
+                {
+                  "total": 110.8,
+                  "quantity": 2,
+                  "interest_percent": 4.53,
+                  "interest_amount": 4.8,
+                  "installment_amount": 55.4
+                },
+                {
+                  "total": 112.47,
+                  "quantity": 3,
+                  "interest_percent": 6.09,
+                  "interest_amount": 6.47,
+                  "installment_amount": 37.49
+                },
+                {
+                  "total": 114.16,
+                  "quantity": 4,
+                  "interest_percent": 7.7,
+                  "interest_amount": 8.16,
+                  "installment_amount": 28.54
+                },
+                {
+                  "total": 115.9,
+                  "quantity": 5,
+                  "interest_percent": 9.33,
+                  "interest_amount": 9.9,
+                  "installment_amount": 23.18
+                },
+                {
+                  "total": 117.6,
+                  "quantity": 6,
+                  "interest_percent": 10.96,
+                  "interest_amount": 11.6,
+                  "installment_amount": 19.6
+                },
+                {
+                  "total": 119.42,
+                  "quantity": 7,
+                  "interest_percent": 12.63,
+                  "interest_amount": 13.42,
+                  "installment_amount": 17.06
+                },
+                {
+                  "total": 121.28,
+                  "quantity": 8,
+                  "interest_percent": 14.44,
+                  "interest_amount": 15.28,
+                  "installment_amount": 15.16
+                },
+                {
+                  "total": 123.12,
+                  "quantity": 9,
+                  "interest_percent": 16.19,
+                  "interest_amount": 17.12,
+                  "installment_amount": 13.68
+                },
+                {
+                  "total": 125.1,
+                  "quantity": 10,
+                  "interest_percent": 18.01,
+                  "interest_amount": 19.1,
+                  "installment_amount": 12.51
+                },
+                {
+                  "total": 126.83,
+                  "quantity": 11,
+                  "interest_percent": 19.66,
+                  "interest_amount": 20.83,
+                  "installment_amount": 11.53
+                },
+                {
+                  "total": 129.0,
+                  "quantity": 12,
+                  "interest_percent": 21.65,
+                  "interest_amount": 23.0,
+                  "installment_amount": 10.75
+                }
+              ],
+              "cards": [],
+              "brands": [
+                "visa",
+                "mastercard",
+                "diners",
+                "hipercard",
+                "amex",
+                "elo",
+                "jcb"
+              ],
+              "amount": 106.0
+            },
+            {
+              "method": "billet",
+              "amount": 106.0
+            }
+          ]
         }';
 
         return $jsonSuccess;

--- a/tests/Unit/Parser/RakutenPay/Transaction/CheckoutTest.php
+++ b/tests/Unit/Parser/RakutenPay/Transaction/CheckoutTest.php
@@ -55,14 +55,12 @@ class CheckoutTest extends TestCase
                 "installment_amount" => 2613.25,
             ]
         ];
-        $method = "credit_card";
         $response = new Response();
         $response->setStatus(Status::OK);
         $response->setResult(json_encode($installments));
 
         $this->checkout->setResult($result);
         $this->checkout->setInstallments($installments);
-        $this->checkout->setMethod($method);
         $this->checkout->setResponse($response);
         $this->checkout->setMessage('');
 
@@ -70,7 +68,6 @@ class CheckoutTest extends TestCase
         $this->assertInstanceOf(Response::class, $this->checkout->getResponse());
         $this->assertCount(2, $this->checkout->getInstallments(), "Checkout Transaction - Count Installments");
         $this->assertEquals($result, $this->checkout->getResult(), "Checkout Transaction Result");
-        $this->assertEquals($method, $this->checkout->getMethod(), "Checkout Transaction Method");
         $this->assertEmpty($this->checkout->getMessage());
     }
 }


### PR DESCRIPTION
# Propósito

**Jira Card:** [[Magento2] Ajustar o parse dos juros comprador no SDK](https://rakutenbrazil.atlassian.net/browse/PAY-527)

Este PR Corrige o parse do response do Juros comprador.
 
# Tarefas Realizadas

- [X] Alterado o checkout
- [X] Ajustados os testes.
- [X] Removido o Method da Classe do Checkout